### PR TITLE
adjust SSH_AUT_SOCK detection to work in Windows WSL

### DIFF
--- a/ssh_setup.sh
+++ b/ssh_setup.sh
@@ -1,16 +1,21 @@
 # Bash function to add in .bashrc or .profile to idempotently setup an SSH agent for the current user
 
 function setup_ssh {
+  # set -x
   cagent=$( pidof -s ssh-agent );
-  SSH_AUTH_SOCK=$( find /tmp -maxdepth 2 -iname 'agent*' -uid $( id -u ) 2>/dev/null | head -n1 );
 
-  if [ -z ${cagent} ] || [ -z ${SSH_AUTH_SOCK} ];
+  if [ -z ${cagent} ];
   then
     # Start a new ssh-agent with 24h expiration of keys
     eval $( /usr/bin/ssh-agent -t 86400 -s );
   else
-    # Connect to an existing ssh-agent
-    export SSH_AUTH_SOCK;
+    # Connect to the most recent ssh-agent
+    SSH_AUTH_SOCK=$(
+      find /tmp -maxdepth 2 -iname 'agent*' -uid $( id -u ) -print0 2>/dev/null | \
+      xargs -0 stat -c "%Y %n" | \
+      sort -nr | \
+      awk '{print $2; exit}'
+    )
     export SSH_AGENT_PID=${cagent};
     echo "Agent PID: ${SSH_AGENT_PID}";
   fi
@@ -21,7 +26,7 @@ function setup_ssh {
     echo "Identity present in agent";
   else
     # Add default key to agent
-    /usr/bin/ssh-add;
+    /usr/bin/ssh-add -t 43200;
   fi
 
   echo "Done"


### PR DESCRIPTION
Double up on the default timeout of a key.

Made the SSH_AUTH_SOCK a little smarter to get the most recent agent if multiple are found and to make the function compatible with Windows' WSL.